### PR TITLE
ERROR solving.

### DIFF
--- a/third_parties/lpips/lpips.py
+++ b/third_parties/lpips/lpips.py
@@ -11,6 +11,9 @@ import torch.nn
 
 from . import *
 
+def normalize_tensor(in_feat,eps=1e-10):
+    norm_factor = torch.sqrt(torch.sum(in_feat**2,dim=1,keepdim=True))
+    return in_feat/(norm_factor+eps)
 
 def spatial_average(in_tens, keepdim=True):
     return in_tens.mean([2,3],keepdim=keepdim)


### PR DESCRIPTION
copy `normalize_tensor` function from 'lpips/__init__.py', to figure the ERROR:  `NameError: name 'normalize_tensor' is not defined` , which appears while run `python fit.py --config-name SNARF_NGP_fitting dataset=$dataset experiment=$experiment deformer=smpl train.max_epochs=200`