### PR TITLE
Install kaolin in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,3 +11,4 @@ pip install smplx==0.1.28
 pip install hydra-core==1.1.2
 pip install h5py ninja chumpy numpy==1.23.1
 pip install lpips
+pip install kaolin==0.15.0 -f https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-1.13.1_cu116.html


### PR DESCRIPTION
Is there a reason why the installation of kaolin is not included in `install.sh`? I faced similar problem in #46 after re-setting up the environment and solved it by installing kaolin according to [kaolin installation guide](https://kaolin.readthedocs.io/en/latest/notes/installation.html).